### PR TITLE
Add basic script builder UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>BOTC Script Builder</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,10 @@
-#root {
-  max-width: 1280px;
+.App {
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 1rem;
 }
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+.character-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,91 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useMemo, useState } from 'react';
+import editions from './data/editions';
+import CharacterCard from './components/CharacterCard.jsx';
+import FilterPanel from './components/FilterPanel.jsx';
+import ScriptPanel from './components/ScriptPanel.jsx';
+import './App.css';
+import './components/CharacterCard.css';
+import './components/FilterPanel.css';
+import './components/ScriptPanel.css';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const teams = ['townsfolk', 'outsider', 'minion', 'demon', 'traveler'];
+  const [editionFilter, setEditionFilter] = useState(() =>
+    Object.fromEntries(editions.map((ed) => [ed.id, true]))
+  );
+  const [teamFilter, setTeamFilter] = useState(() =>
+    Object.fromEntries(teams.map((t) => [t, true]))
+  );
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState([]);
+
+  const allCharacters = useMemo(
+    () =>
+      editions.flatMap((ed) =>
+        editionFilter[ed.id]
+          ? ed.characters.map((c) => ({ ...c, edition: ed.id }))
+          : []
+      ),
+    [editionFilter]
+  );
+
+  const filtered = allCharacters.filter(
+    (c) => teamFilter[c.team] && c.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const toggleSelect = (char) => {
+    setSelected((prev) =>
+      prev.find((c) => c.id === char.id)
+        ? prev.filter((c) => c.id !== char.id)
+        : [...prev, char]
+    );
+  };
+
+  const remove = (id) => setSelected((prev) => prev.filter((c) => c.id !== id));
+  const clear = () => setSelected([]);
+  const randomize = () => {
+    const pool = filtered;
+    const count = Math.min(15, pool.length);
+    const shuffled = [...pool].sort(() => Math.random() - 0.5);
+    setSelected(shuffled.slice(0, count));
+  };
+  const sortSelected = () => {
+    const order = { townsfolk: 0, outsider: 1, minion: 2, demon: 3, traveler: 4 };
+    setSelected((prev) => [...prev].sort((a, b) => order[a.team] - order[b.team]));
+  };
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <div className="App">
+      <h1>Blood on the Clocktower Script Builder</h1>
+      <FilterPanel
+        editions={editions}
+        editionFilter={editionFilter}
+        setEditionFilter={setEditionFilter}
+        teams={teams}
+        teamFilter={teamFilter}
+        setTeamFilter={setTeamFilter}
+        search={search}
+        setSearch={setSearch}
+      />
+      <div className="character-grid">
+        {filtered.map((char) => (
+          <CharacterCard
+            key={char.id}
+            character={char}
+            selected={selected.some((c) => c.id === char.id)}
+            onToggle={() => toggleSelect(char)}
+          />
+        ))}
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+      <ScriptPanel
+        selected={selected}
+        onRemove={remove}
+        onClear={clear}
+        onRandom={randomize}
+        onSort={sortSelected}
+      />
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/src/components/CharacterCard.css
+++ b/src/components/CharacterCard.css
@@ -1,0 +1,27 @@
+.character-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 150px;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin: 0.5rem;
+  cursor: pointer;
+  background-color: #f9f9f9;
+}
+.character-card.selected {
+  border-color: #646cff;
+}
+.character-image {
+  width: 100px;
+  height: 100px;
+  object-fit: contain;
+}
+.character-info {
+  text-align: center;
+}
+.team {
+  font-size: 0.8rem;
+  color: #666;
+}

--- a/src/components/CharacterCard.jsx
+++ b/src/components/CharacterCard.jsx
@@ -1,0 +1,15 @@
+import './CharacterCard.css';
+
+function CharacterCard({ character, selected, onToggle }) {
+  return (
+    <div className={`character-card ${selected ? 'selected' : ''}`} onClick={onToggle}>
+      <img src={character.image} alt={character.name} className="character-image" />
+      <div className="character-info">
+        <h4>{character.name}</h4>
+        <p className="team">{character.team}</p>
+      </div>
+    </div>
+  );
+}
+
+export default CharacterCard;

--- a/src/components/FilterPanel.css
+++ b/src/components/FilterPanel.css
@@ -1,0 +1,10 @@
+.filter-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.filter-group {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -1,0 +1,37 @@
+function FilterPanel({ editions, editionFilter, setEditionFilter, teams, teamFilter, setTeamFilter, search, setSearch }) {
+  const handleEditionChange = (id) => {
+    setEditionFilter({ ...editionFilter, [id]: !editionFilter[id] });
+  };
+
+  const handleTeamChange = (team) => {
+    setTeamFilter({ ...teamFilter, [team]: !teamFilter[team] });
+  };
+
+  return (
+    <div className="filter-panel">
+      <div className="filter-group">
+        <h3>Edition</h3>
+        {editions.map((ed) => (
+          <label key={ed.id}>
+            <input type="checkbox" checked={editionFilter[ed.id]} onChange={() => handleEditionChange(ed.id)} />
+            {ed.name}
+          </label>
+        ))}
+      </div>
+      <div className="filter-group">
+        <h3>Team</h3>
+        {teams.map((team) => (
+          <label key={team}>
+            <input type="checkbox" checked={teamFilter[team]} onChange={() => handleTeamChange(team)} />
+            {team}
+          </label>
+        ))}
+      </div>
+      <div className="filter-group">
+        <input type="text" placeholder="Search" value={search} onChange={(e) => setSearch(e.target.value)} />
+      </div>
+    </div>
+  );
+}
+
+export default FilterPanel;

--- a/src/components/ScriptPanel.css
+++ b/src/components/ScriptPanel.css
@@ -1,0 +1,27 @@
+.script-panel {
+  margin-top: 1rem;
+  border-top: 1px solid #ccc;
+  padding-top: 1rem;
+}
+.selected-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.selected-item {
+  padding: 0.25rem 0.5rem;
+  background: #eee;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.script-buttons button {
+  margin-right: 0.5rem;
+}
+.json-preview {
+  max-height: 200px;
+  overflow: auto;
+  background: #f0f0f0;
+  padding: 0.5rem;
+  text-align: left;
+}

--- a/src/components/ScriptPanel.jsx
+++ b/src/components/ScriptPanel.jsx
@@ -1,0 +1,36 @@
+function ScriptPanel({ selected, onRemove, onClear, onRandom, onSort }) {
+  const json = JSON.stringify(selected.map((c) => c.id), null, 2);
+  const copy = () => navigator.clipboard.writeText(json);
+  const download = () => {
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'script.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="script-panel">
+      <h3>Selected Characters ({selected.length})</h3>
+      <div className="selected-list">
+        {selected.map((c) => (
+          <span key={c.id} className="selected-item" onClick={() => onRemove(c.id)}>
+            {c.name}
+          </span>
+        ))}
+      </div>
+      <div className="script-buttons">
+        <button onClick={onRandom}>Randomize</button>
+        <button onClick={onSort}>Sort</button>
+        <button onClick={onClear}>Clear</button>
+      </div>
+      <pre className="json-preview">{json}</pre>
+      <button onClick={copy}>Copy JSON</button>
+      <button onClick={download}>Download JSON</button>
+    </div>
+  );
+}
+
+export default ScriptPanel;

--- a/src/data/editions.js
+++ b/src/data/editions.js
@@ -1,0 +1,18 @@
+import tbData from './original_sheets/trouble_brewing.json';
+import bmrData from './original_sheets/bad_moon_rising.json';
+import svData from './original_sheets/sects_and_violets.json';
+
+function parseEdition(data) {
+  const [meta, ...characters] = data;
+  const editionId = characters[0]?.edition || '';
+  return {
+    id: editionId,
+    name: meta.name,
+    background: meta.background,
+    characters,
+  };
+}
+
+const editions = [parseEdition(tbData), parseEdition(bmrData), parseEdition(svData)];
+
+export default editions;


### PR DESCRIPTION
## Summary
- switch site title to *BOTC Script Builder*
- add React components for filtering, card view and script preview
- create editions loader for JSON character data
- implement filter, search, randomize and export functions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68775f277d4083228f0efee71a76a75f