### PR TITLE
Layout and export improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,8 +3,19 @@
   margin: 0 auto;
   padding: 1rem;
 }
+.main-layout {
+  display: flex;
+  gap: 1rem;
+}
+.left-column,
+.right-column {
+  flex: 1;
+}
 .character-grid {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  background-color: #f9f9f9;
+  padding: 1rem;
+  border-radius: 4px;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,33 +57,39 @@ function App() {
   return (
     <div className="App">
       <h1>Blood on the Clocktower Script Builder</h1>
-      <FilterPanel
-        editions={editions}
-        editionFilter={editionFilter}
-        setEditionFilter={setEditionFilter}
-        teams={teams}
-        teamFilter={teamFilter}
-        setTeamFilter={setTeamFilter}
-        search={search}
-        setSearch={setSearch}
-      />
-      <div className="character-grid">
-        {filtered.map((char) => (
-          <CharacterCard
-            key={char.id}
-            character={char}
-            selected={selected.some((c) => c.id === char.id)}
-            onToggle={() => toggleSelect(char)}
+      <div className="main-layout">
+        <div className="left-column">
+          <FilterPanel
+            editions={editions}
+            editionFilter={editionFilter}
+            setEditionFilter={setEditionFilter}
+            teams={teams}
+            teamFilter={teamFilter}
+            setTeamFilter={setTeamFilter}
+            search={search}
+            setSearch={setSearch}
           />
-        ))}
+          <div className="character-grid">
+            {filtered.map((char) => (
+              <CharacterCard
+                key={char.id}
+                character={char}
+                selected={selected.some((c) => c.id === char.id)}
+                onToggle={() => toggleSelect(char)}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="right-column">
+          <ScriptPanel
+            selected={selected}
+            onRemove={remove}
+            onClear={clear}
+            onRandom={randomize}
+            onSort={sortSelected}
+          />
+        </div>
       </div>
-      <ScriptPanel
-        selected={selected}
-        onRemove={remove}
-        onClear={clear}
-        onRandom={randomize}
-        onSort={sortSelected}
-      />
     </div>
   );
 }

--- a/src/components/FilterPanel.css
+++ b/src/components/FilterPanel.css
@@ -3,6 +3,9 @@
   flex-wrap: wrap;
   gap: 1rem;
   margin-bottom: 1rem;
+  background-color: #eef2ff;
+  padding: 1rem;
+  border-radius: 4px;
 }
 .filter-group {
   display: flex;

--- a/src/components/ScriptPanel.css
+++ b/src/components/ScriptPanel.css
@@ -2,6 +2,9 @@
   margin-top: 1rem;
   border-top: 1px solid #ccc;
   padding-top: 1rem;
+  background-color: #fffbe6;
+  padding: 1rem;
+  border-radius: 4px;
 }
 .selected-list {
   display: flex;

--- a/src/components/ScriptPanel.jsx
+++ b/src/components/ScriptPanel.jsx
@@ -1,5 +1,5 @@
 function ScriptPanel({ selected, onRemove, onClear, onRandom, onSort }) {
-  const json = JSON.stringify(selected.map((c) => c.id), null, 2);
+  const json = JSON.stringify(selected, null, 2);
   const copy = () => navigator.clipboard.writeText(json);
   const download = () => {
     const blob = new Blob([json], { type: 'application/json' });


### PR DESCRIPTION
## Summary
- restructure app layout into two columns
- add background colors for each section
- export full character objects in ScriptPanel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6877636011bc832283650c57f3ef57a5