### PR TITLE
Add Loader component

### DIFF
--- a/src/components/Loader.css
+++ b/src/components/Loader.css
@@ -1,0 +1,58 @@
+.sk-cube-grid {
+  width: 40px;
+  height: 40px;
+  margin: 20px auto;
+}
+
+.sk-cube-grid .sk-cube {
+  width: 33%;
+  height: 33%;
+  background-color: #333;
+  float: left;
+  animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
+}
+
+.sk-cube-grid .sk-cube1 {
+  animation-delay: 0.2s;
+}
+
+.sk-cube-grid .sk-cube2 {
+  animation-delay: 0.3s;
+}
+
+.sk-cube-grid .sk-cube3 {
+  animation-delay: 0.4s;
+}
+
+.sk-cube-grid .sk-cube4 {
+  animation-delay: 0.1s;
+}
+
+.sk-cube-grid .sk-cube5 {
+  animation-delay: 0.2s;
+}
+
+.sk-cube-grid .sk-cube6 {
+  animation-delay: 0.3s;
+}
+
+.sk-cube-grid .sk-cube7 {
+  animation-delay: 0s;
+}
+
+.sk-cube-grid .sk-cube8 {
+  animation-delay: 0.1s;
+}
+
+.sk-cube-grid .sk-cube9 {
+  animation-delay: 0.2s;
+}
+
+@keyframes sk-cubeGridScaleDelay {
+  0%, 70%, 100% {
+    transform: scale3D(1, 1, 1);
+  }
+  35% {
+    transform: scale3D(0, 0, 1);
+  }
+}

--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -1,0 +1,13 @@
+import './Loader.css';
+
+function Loader() {
+  return (
+    <div className="sk-cube-grid" data-testid="loader">
+      {Array.from({ length: 9 }, (_, i) => (
+        <div key={i} className={`sk-cube sk-cube${i + 1}`} />
+      ))}
+    </div>
+  );
+}
+
+export default Loader;


### PR DESCRIPTION
## Summary
- add `Loader` component for loading states
- style loader with cube grid animation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6877806b36848322b4ee2bf075f20e7d