### PR TITLE
Update styles and assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Build custom Blood on the Clocktower scripts online" />
+    <meta property="og:title" content="Blood on the Clocktower Script Builder" />
     <title>BOTC Script Builder</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -15,8 +15,8 @@
 .side-panel {
   width: 340px;
   flex-shrink: 0;
-  background: #333;
-  color: #fff;
+  background: #f5f5f5;
+  color: #333;
   padding: 1rem;
   box-sizing: border-box;
   overflow-y: auto;
@@ -26,7 +26,7 @@
 .sheet-panel {
   flex: 1;
   background: #fff;
-  color: #000;
+  color: #333;
   padding: 1rem;
   box-sizing: border-box;
   overflow-y: auto;

--- a/src/components/CharacterCard.css
+++ b/src/components/CharacterCard.css
@@ -4,11 +4,12 @@
   align-items: center;
   width: 150px;
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  border: 1px solid #ddd;
   border-radius: 4px;
   margin: 0.5rem;
   cursor: pointer;
-  background-color: #f9f9f9;
+  background-color: #ffffff;
+  color: #333;
 }
 .character-card.selected {
   border-color: #646cff;

--- a/src/components/FilterPanel.css
+++ b/src/components/FilterPanel.css
@@ -2,9 +2,10 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  background-color: #eef2ff;
+  background-color: #f7f7f7;
   padding: 1rem;
   border-radius: 4px;
+  color: #333;
 }
 .filter-group {
   display: flex;

--- a/src/components/Loader.css
+++ b/src/components/Loader.css
@@ -1,0 +1,32 @@
+.sk-cube-grid {
+  width: 40px;
+  height: 40px;
+  margin: 40px auto;
+}
+
+.sk-cube-grid .sk-cube {
+  width: 33%;
+  height: 33%;
+  background-color: #333;
+  float: left;
+  animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
+}
+
+.sk-cube-grid .sk-cube1 { animation-delay: 0.2s; }
+.sk-cube-grid .sk-cube2 { animation-delay: 0.3s; }
+.sk-cube-grid .sk-cube3 { animation-delay: 0.4s; }
+.sk-cube-grid .sk-cube4 { animation-delay: 0.1s; }
+.sk-cube-grid .sk-cube5 { animation-delay: 0.2s; }
+.sk-cube-grid .sk-cube6 { animation-delay: 0.3s; }
+.sk-cube-grid .sk-cube7 { animation-delay: 0s; }
+.sk-cube-grid .sk-cube8 { animation-delay: 0.1s; }
+.sk-cube-grid .sk-cube9 { animation-delay: 0.2s; }
+
+@keyframes sk-cubeGridScaleDelay {
+  0%, 70%, 100% {
+    transform: scale3D(1, 1, 1);
+  }
+  35% {
+    transform: scale3D(0, 0, 1);
+  }
+}

--- a/src/components/ScriptPanel.css
+++ b/src/components/ScriptPanel.css
@@ -1,9 +1,10 @@
 .script-panel {
   margin-top: 1rem;
   border-top: 1px solid #ccc;
-  background-color: #fffde7;
+  background-color: #fff9e6;
   padding: 1rem;
   border-radius: 4px;
+  color: #333;
 }
 .selection {
   display: flex;

--- a/src/components/SheetView.css
+++ b/src/components/SheetView.css
@@ -19,6 +19,7 @@
   background: #fff;
   padding: 1rem;
   border-radius: 4px;
+  color: #333;
 }
 
 .team-section {
@@ -30,6 +31,7 @@
   background: #f0f0f0;
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
+  color: #333;
 }
 
 table {

--- a/src/index.css
+++ b/src/index.css
@@ -1,16 +1,9 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: light dark;
 }
 
 a {
@@ -24,10 +17,13 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: #333;
+  background: url('/images/website/bg-mandala.webp') top right repeat;
 }
 
 h1 {
@@ -56,7 +52,7 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
+    color: #333;
     background-color: #ffffff;
   }
   a:hover {


### PR DESCRIPTION
## Summary
- update base styles with new fonts, colors and mandala background
- tweak component styling for lighter panels and darker text
- add loader CSS for `.sk-cube-grid` spinner
- set favicon and meta tags in `index.html`
- include asset placeholder directory

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6877832786ec83228f246b90b59c74fe