### PR TITLE
Add character data module

### DIFF
--- a/src/data/characters.ts
+++ b/src/data/characters.ts
@@ -1,0 +1,34 @@
+import editions from './editions.js';
+
+export interface Character {
+  id: string;
+  name: string;
+  ability: string;
+  edition: string;
+  team: 'townsfolk' | 'outsider' | 'minion' | 'demon' | 'traveler';
+  image: string;
+  [key: string]: unknown;
+}
+
+interface Edition {
+  id: string;
+  name: string;
+  background: string;
+  characters: Character[];
+}
+
+export const editionsList: Edition[] = editions as Edition[];
+
+export const characters: Character[] = editionsList.flatMap((e) => e.characters);
+
+export const teams = ['townsfolk', 'outsider', 'minion', 'demon', 'traveler'] as const;
+
+export const teamDisplayNames: Record<(typeof teams)[number], string> = {
+  townsfolk: '마을 주민',
+  outsider: '외부인',
+  minion: '하수인',
+  demon: '악마',
+  traveler: '여행자',
+};
+
+export { editionsList as editions };


### PR DESCRIPTION
## Summary
- add `src/data/characters.ts` exporting characters, editions, teams and display names

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to resolve /src/main.jsx)*

------
https://chatgpt.com/codex/tasks/task_b_687897e3af3c83228ef29ef1c30c62b6